### PR TITLE
feat(cli): Add filter logic to debug flag

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,9 +50,9 @@ export class CLI {
 
     let parsed = parser.parse(argv);
 
-    if (parsed.debug) {
+    if (parsed.debug != null) {
       const debug = require('debug');
-      debug.enable('acot:*');
+      debug.enable(`acot:${parsed.debug || '*'}`);
     }
 
     if (parsed.quiet) {

--- a/packages/cli/src/commands/__tests__/__snapshots__/help.test.ts.snap
+++ b/packages/cli/src/commands/__tests__/__snapshots__/help.test.ts.snap
@@ -16,7 +16,7 @@ COMMAND OPTIONS
 GLOBAL OPTIONS
   -q, --quiet                              Disable stdout/stderr
   -v, --verbose                            Enable logging.
-      --debug                              Dump debug infomation for acot modules.
+      --debug                              Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug \\"core\\")
       --no-color                           Force disabling of color
       --help                               Show help
       --version                            Output the version number"
@@ -36,7 +36,7 @@ COMMAND OPTIONS
 GLOBAL OPTIONS
   -q, --quiet     Disable stdout/stderr
   -v, --verbose   Enable logging.
-      --debug     Dump debug infomation for acot modules.
+      --debug     Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug \\"core\\")
       --no-color  Force disabling of color
       --help      Show help
       --version   Output the version number"
@@ -51,7 +51,7 @@ USAGE
 GLOBAL OPTIONS
   -q, --quiet     Disable stdout/stderr
   -v, --verbose   Enable logging.
-      --debug     Dump debug infomation for acot modules.
+      --debug     Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug \\"core\\")
       --no-color  Force disabling of color
       --help      Show help
       --version   Output the version number"
@@ -71,7 +71,7 @@ AVAILABLE COMMANDS
 GLOBAL OPTIONS
   -q, --quiet      Disable stdout/stderr
   -v, --verbose    Enable logging.
-      --debug      Dump debug infomation for acot modules.
+      --debug      Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug \\"core\\")
       --no-color   Force disabling of color
       --help       Show help
       --version    Output the version number
@@ -93,7 +93,7 @@ COMMAND OPTIONS
 GLOBAL OPTIONS
   -q, --quiet     Disable stdout/stderr
   -v, --verbose   Enable logging.
-      --debug     Dump debug infomation for acot modules.
+      --debug     Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug \\"core\\")
       --no-color  Force disabling of color
       --help      Show help
       --version   Output the version number"

--- a/packages/cli/src/global-options.ts
+++ b/packages/cli/src/global-options.ts
@@ -10,8 +10,9 @@ export const globalOptions = {
     description: 'Enable logging.',
   },
   debug: {
-    type: 'boolean',
-    description: 'Dump debug infomation for acot modules.',
+    type: 'string',
+    description:
+      'Dump debug information for acot modules. Can filter output by specifying the module name. (e.g. --debug "core")',
   },
   'no-color': {
     type: 'boolean',


### PR DESCRIPTION
## What does this change?

I added filter logic to the debug flag.
It can be used as follows:

```bash
$ acot run --debug "*"
$ acot run --debug "core"
$ acot run --debug "@acot/wcag/*"
```

## Screenshots

- Nothing.

## What can I check for bug fixes?

- Nothing.

## References

- Nothing.
