### PR TITLE
Add rule focusable has indicator

### DIFF
--- a/packages/acot-preset-wcag/.scaffdog/01-rule.md
+++ b/packages/acot-preset-wcag/.scaffdog/01-rule.md
@@ -12,7 +12,7 @@ ignore: ['**/*']
 ````markdown
 # {{ input }}
 
-> **TODO:**Short summary.
+**TODO:**Short summary.
 
 **TODO:** Description.
 

--- a/packages/acot-preset-wcag/docs/rules/focusable-has-indicator.md
+++ b/packages/acot-preset-wcag/docs/rules/focusable-has-indicator.md
@@ -1,0 +1,40 @@
+# focusable-has-indicator
+
+Focusable elemenet has a focus indicator.
+
+> Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible. [WCAG 2.1 - 2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)
+
+**WARN: Test will fail when make focus indicator without style of focused element.**
+
+## :white_check_mark: Correct
+
+```html
+<p>
+  <a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html"
+    >WCAG 2.1 - 2.4.7: Focus Visible</a
+  >
+</p>
+```
+
+```html
+<button type="button">Button styled with border</button>
+
+<style>
+  button:focus {
+    outline: none;
+    border: 3px solid black;
+  }
+</style>
+```
+
+## :warning: Incorrect
+
+```html
+<button type="button">Button styled with outline: none</button>
+
+<style>
+  *:focus {
+    outline: none;
+  }
+</style>
+```

--- a/packages/acot-preset-wcag/src/rules/focusable-has-indicator.ts
+++ b/packages/acot-preset-wcag/src/rules/focusable-has-indicator.ts
@@ -1,0 +1,67 @@
+import { createRule } from '@acot/core';
+
+const SELECTOR = [
+  'input',
+  'select',
+  'textarea',
+  'a[href]',
+  'button',
+  '[tabindex]',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  'details>summary:first-of-type',
+  'details',
+].join(',');
+
+type Options = {};
+
+export default createRule<Options>({
+  type: 'contextual',
+  selector: SELECTOR,
+  immutable: true,
+  meta: {
+    tags: ['wcag21aa', '2.4.7 Focus visible'],
+    recommended: true,
+  },
+
+  test: async (context, node) => {
+    const getComputedOutlineStyleAndCssText = (el: Element) => {
+      const CSSStyleDeclaration = window.getComputedStyle(el);
+
+      return {
+        outline: {
+          color: CSSStyleDeclaration.outlineColor,
+          style: CSSStyleDeclaration.outlineStyle,
+          width: CSSStyleDeclaration.outlineWidth,
+        },
+        cssText: CSSStyleDeclaration.cssText,
+      };
+    };
+
+    const beforeStyle = await node.evaluate(getComputedOutlineStyleAndCssText);
+
+    context.debug({ beforeStyle });
+
+    await node.focus();
+
+    const afterStyle = await node.evaluate(getComputedOutlineStyleAndCssText);
+
+    context.debug({ afterStyle });
+
+    if (
+      afterStyle.outline.color !== 'transparent' &&
+      afterStyle.outline.style !== 'none' &&
+      afterStyle.outline.width !== '0px'
+    ) {
+      return;
+    }
+
+    if (beforeStyle.cssText === afterStyle.cssText) {
+      await context.report({
+        node,
+        message: `The focusable element MUST have visible focus indicator when focused.`,
+      });
+    }
+  },
+});

--- a/packages/acot-preset-wcag/src/rules/index.ts
+++ b/packages/acot-preset-wcag/src/rules/index.ts
@@ -6,6 +6,7 @@ import pageHasTitle from './page-has-title';
 import imgHasName from './img-has-name';
 import dialogFocus from './dialog-focus';
 import pageHasValidLang from './page-has-valid-lang';
+import focusableHasIndicator from './focusable-has-indicator';
 
 export const rules: RuleRecord = {
   'interactive-has-enough-size': interactiveHasEnoughSize,
@@ -15,4 +16,5 @@ export const rules: RuleRecord = {
   'page-has-valid-lang': pageHasValidLang,
   'img-has-name': imgHasName,
   'dialog-focus': dialogFocus,
+  'focusable-has-indicator': focusableHasIndicator,
 };


### PR DESCRIPTION
## What does this change?

Add focusable-has-indicator rule.

This rule checks if the outline property has not been deleted or if the element style has been changed by comparing the before and after focus.

So test will failed in case of implement focus style by other element.

## References

- Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible. [WCAG 2.1 - 2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)
