### PR TITLE
feat(cli): Skip ask about puppeteer if installed

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -92,6 +92,15 @@ const validateNpmClient: Validator = (value) => {
   return true;
 };
 
+const isPuppeteerInstalled = (): boolean => {
+  try {
+    const puppeteer = require('puppeteer');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const promptUserIfNeeded = async (defaults: Partial<PromptResult>) => {
   const result: PromptResult = {
     origin: '',
@@ -210,12 +219,16 @@ const promptUserIfNeeded = async (defaults: Partial<PromptResult>) => {
   if (defaults.installPuppeteer !== undefined) {
     result.installPuppeteer = defaults.installPuppeteer;
   } else {
-    result.installPuppeteer = await prompt({
-      type: 'toggle',
-      name: 'installPuppeteer',
-      message: 'Do you want to install Puppeteer as a dependency?',
-      initial: 1,
-    });
+    if (isPuppeteerInstalled()) {
+      result.installPuppeteer = false;
+    } else {
+      result.installPuppeteer = await prompt({
+        type: 'toggle',
+        name: 'installPuppeteer',
+        message: 'Do you want to install Puppeteer as a dependency?',
+        initial: 1,
+      });
+    }
   }
 
   if (defaults.npmClient !== undefined) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -94,7 +94,7 @@ const validateNpmClient: Validator = (value) => {
 
 const isPuppeteerInstalled = (): boolean => {
   try {
-    const puppeteer = require('puppeteer');
+    require('puppeteer');
     return true;
   } catch {
     return false;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,6 +9,7 @@ import Listr from 'listr';
 import { emojify } from 'node-emoji';
 import prettier from 'prettier';
 import isURL from 'validator/lib/isURL';
+import { findChrome } from '@acot/find-chrome';
 import { createCommand } from '../command';
 import { debug } from '../logging';
 
@@ -92,13 +93,8 @@ const validateNpmClient: Validator = (value) => {
   return true;
 };
 
-const isPuppeteerInstalled = (): boolean => {
-  try {
-    require('puppeteer');
-    return true;
-  } catch {
-    return false;
-  }
+const isPuppeteerInstalled = async (): Promise<boolean> => {
+  return (await findChrome({ channel: 'puppeteer' })) !== null;
 };
 
 const promptUserIfNeeded = async (defaults: Partial<PromptResult>) => {
@@ -219,7 +215,7 @@ const promptUserIfNeeded = async (defaults: Partial<PromptResult>) => {
   if (defaults.installPuppeteer !== undefined) {
     result.installPuppeteer = defaults.installPuppeteer;
   } else {
-    if (isPuppeteerInstalled()) {
+    if (await isPuppeteerInstalled()) {
       result.installPuppeteer = false;
     } else {
       result.installPuppeteer = await prompt({


### PR DESCRIPTION
## What does this change?

If a user already installed puppeteer as dev dependency, skip a question about whether to install puppeteer or not in the configuration wizard of `acot init`.

I believe this change will improves user experience, especially beginners who choose `npm install --save-dev @acot/cli puppeteer`.

## Screenshots

![Default_and_init_ts_—_acot](https://user-images.githubusercontent.com/151614/102238725-70051880-3f39-11eb-9cd2-05de80c5d1b5.png)

## References

N/A