### PR TITLE
fix(acot-preset-wcag): fix focusable-has-indicator bug

### DIFF
--- a/packages/acot-preset-wcag/docs/rules/focusable-has-indicator.md
+++ b/packages/acot-preset-wcag/docs/rules/focusable-has-indicator.md
@@ -9,11 +9,21 @@ Focusable element has a focus indicator.
 ## :white_check_mark: Correct
 
 ```html
-<p>
-  <a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html"
-    >WCAG 2.1 - 2.4.7: Focus Visible</a
-  >
-</p>
+<a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html"
+  >WCAG 2.1 - 2.4.7: Focus Visible</a
+>
+
+<button type="button">button</button>
+```
+
+```html
+<a href="#">Custom Outline style</a>
+
+<style>
+  *:focus {
+    outline: 3px double black;
+  }
+</style>
 ```
 
 ```html
@@ -30,10 +40,14 @@ Focusable element has a focus indicator.
 ## :warning: Incorrect
 
 ```html
+<!-- correct case -->
+<a href="#">Custom Outline style</a>
+
+<!-- incorrect case -->
 <button type="button">Button styled with outline: none</button>
 
 <style>
-  *:focus {
+  button:focus {
     outline: none;
   }
 </style>


### PR DESCRIPTION
## What does this change?

Fix @acot/wcag/focusable-has-indicator bug.

@acot/wcag/focusable-has-indicator rule implemented in contextual is executed in parallel in Promise.all, so if there are multiple focusable elements in a page, the focus will move and the style will not be accurate.

## Screenshots

none.

## What can I check for bug fixes?

Please check result of test that in page has multiple focusable elements.

## References

```TypeScript
case 'contextual': {
  try {
    const nodes = await page.$$(rule.selector);

    await Promise.all(
      nodes.map((node) =>
        rule.test(context, node).catch(handleUnexpectedError),
      ),
    );
  } catch (e) {
    this._debug('Not found elements (rule="%s", url="%s")', id, url, e);
  }
  break;
}
```

https://github.com/acot-a11y/acot/blob/canary/packages/core/src/tester.ts#L311-L324