### PR TITLE
Add `pattern` to specify test target

### DIFF
--- a/packages/cli/src/commands/preset-test.ts
+++ b/packages/cli/src/commands/preset-test.ts
@@ -15,7 +15,12 @@ export default createCommand({
   name: 'test',
   summary:
     'Test the rules provided by the preset according to the documentation.',
-  args: {},
+  args: {
+    pattern: {
+      type: 'string',
+      description: 'Rule name pattern to include in the test target.',
+    },
+  },
   options: {
     project: {
       type: 'string',
@@ -60,12 +65,13 @@ export default createCommand({
   });
 
   const tester = new DocTester(server, {});
+
   const reporter = new DocResultReporter({
     origin: `http://localhost:${port}`,
   });
 
   try {
-    const result = await tester.test(project);
+    const result = await tester.test(project, args.pattern);
     debug('result: %O', result);
     logger.print(reporter.format(result));
     return result.errors.length > 0 ? 1 : 0;

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -54,6 +54,7 @@
     "is-plain-object": "^5.0.0",
     "log-symbols": "^4.0.0",
     "mdast-util-to-string": "^2.0.0",
+    "micromatch": "^4.0.2",
     "mustache": "^4.0.1",
     "plur": "^4.0.0",
     "puppeteer-core": "^5.5.0",
@@ -66,6 +67,7 @@
     "unist-util-visit-parents": "^3.1.0"
   },
   "devDependencies": {
+    "@types/micromatch": "4.0.1",
     "@types/mustache": "4.1.1",
     "@types/puppeteer-core": "2.1.0",
     "@types/unist": "2.0.3",


### PR DESCRIPTION
## What does this change?

Added the `pattern` flag to narrow down the test target.

**Example:**

```bash
$ acot preset test "page-*"
```

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a
