### PR TITLE
chore: fix publish config

### DIFF
--- a/packages/acot-config/package.json
+++ b/packages/acot-config/package.json
@@ -20,8 +20,8 @@
   "main": "index.js",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/acot-preset-axe/package.json
+++ b/packages/acot-preset-axe/package.json
@@ -22,8 +22,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/acot-preset-wcag/package.json
+++ b/packages/acot-preset-wcag/package.json
@@ -22,8 +22,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/acot-reporter-dot/package.json
+++ b/packages/acot-reporter-dot/package.json
@@ -21,8 +21,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/acot-reporter-pretty/package.json
+++ b/packages/acot-reporter-pretty/package.json
@@ -21,8 +21,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/acot-runner-sitemap/package.json
+++ b/packages/acot-runner-sitemap/package.json
@@ -21,8 +21,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/acot-runner-storybook/package.json
+++ b/packages/acot-runner-storybook/package.json
@@ -21,8 +21,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/acot-runner/package.json
+++ b/packages/acot-runner/package.json
@@ -21,8 +21,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,8 @@
   },
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "prebuild": "yarn generate",

--- a/packages/connection/package.json
+++ b/packages/connection/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -21,8 +21,9 @@
   "files": [
     "lib",
     "templates",
-    "!__mocks__",
-    "!__tests__"
+    "templates/assets/styles.css",
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "run-p build:*",

--- a/packages/factory/package.json
+++ b/packages/factory/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/find-chrome/package.json
+++ b/packages/find-chrome/package.json
@@ -17,8 +17,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/html-pickup/package.json
+++ b/packages/html-pickup/package.json
@@ -17,8 +17,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/module-loader/package.json
+++ b/packages/module-loader/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/schema-validator/package.json
+++ b/packages/schema-validator/package.json
@@ -17,8 +17,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,8 +20,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!__mocks__",
-    "!__tests__"
+    "!**/__mocks__",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## What does this change?

- Ignore `lib/**/__mocks__` and `lib/**/__tests__` directories in publish code.
- Add missing `.css` file  to `files` field in `@acot/document` package.

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

n/a
