### PR TITLE
Timeout for runners

### DIFF
--- a/packages/acot-runner-sitemap/README.md
+++ b/packages/acot-runner-sitemap/README.md
@@ -51,7 +51,7 @@ The URL of `sitemap.xml`
 }
 ```
 
-## `include`
+### `include`
 
 **Type:** `string[]`  
 **Required:** `false`
@@ -70,7 +70,7 @@ Page path pattern to include in audit target. See the [micromatch][mm] documenta
 }
 ```
 
-## `exclude`
+### `exclude`
 
 **Type:** `string[]`  
 **Required:** `false`
@@ -89,7 +89,7 @@ Page path pattern to exclude in audit target. See the [micromatch][mm] documenta
 }
 ```
 
-## `limit`
+### `limit`
 
 **Type:** `number`  
 **Required:** `false`
@@ -108,7 +108,7 @@ Maximum number of pages to include in the audit target. If no value is specified
 }
 ```
 
-## `random`
+### `random`
 
 **Type:** `{ pattern: string; limit: number }[]`  
 **Required:** `false`
@@ -136,7 +136,7 @@ Randomly include the number of `limit`s in the audit target from the page list t
 }
 ```
 
-## `headers`
+### `headers`
 
 **Type:** `Record<string, string>`  
 **Required:** `false`
@@ -153,6 +153,24 @@ The key-value of the header used when fetching the `sitemap.xml` specified in [s
         "X-KEY": "value"
       }
     }
+  }
+}
+```
+
+### `timeout`
+
+**Type:** `number`  
+**Default:** `60000`  
+**Required:** `false`
+
+Maximum time in milliseconds to wait for collecting sitemaps.
+
+```json
+{
+  "runner": "@acot/sitemap",
+  "with": {
+    "source": "https://acot.example/sitemap.xml",
+    "timeout": 120000
   }
 }
 ```

--- a/packages/acot-runner-storybook/README.md
+++ b/packages/acot-runner-storybook/README.md
@@ -79,6 +79,25 @@ The Story name pattern to exclude in the audit target. See the [micromatch][mm] 
 }
 ```
 
+### `timeout`
+
+**Type:** `number`  
+**Default:** `60000`  
+**Required:** `false`
+
+Maximum time in milliseconds to wait for the browser instance to collect stories.
+
+```json
+{
+  "runner": {
+    "uses": "@acot/storybook",
+    "with": {
+      "timeout": 120000
+    }
+  }
+}
+```
+
 ## Storybook compatibility
 
 ### Storybook versions

--- a/packages/acot-runner-storybook/src/index.ts
+++ b/packages/acot-runner-storybook/src/index.ts
@@ -11,6 +11,8 @@ import type { AcotRunnerCollectResult } from '@acot/acot-runner';
 import { AcotRunner } from '@acot/acot-runner';
 const debug = require('debug')('acot:runner:storybook');
 
+const DEFAULT_TIMEOUT = 60 * 1000;
+
 type StoryParams = Omit<ConfigEntry, 'include' | 'exclude'>;
 
 type Story = {
@@ -73,6 +75,7 @@ const filterStories = (
 type Options = {
   include?: string[];
   exclude?: string[];
+  timeout?: number;
 };
 
 const schema: Schema = {
@@ -89,6 +92,10 @@ const schema: Schema = {
         type: 'string',
       },
     },
+    timeout: {
+      type: 'number',
+      minimum: 0,
+    },
   },
   required: [],
   additionalProperties: false,
@@ -99,6 +106,8 @@ export class StorybookRunner extends AcotRunner<Options> {
     // get stories
     const browser = await puppeteer.launch(this.config.launchOptions);
     const page = await browser.newPage();
+
+    page.setDefaultTimeout(this.options.timeout ?? DEFAULT_TIMEOUT);
 
     let stories: AcotStory[] = [];
 


### PR DESCRIPTION
## What does this change?

Add `timeout` options for acot runners.

```json
{
  "runner": {
    "uses": "@acot/storybook",
    "with": {
      "timeout": 60000
    }
  }
}
```

The runners that support timeout options are:

- `@acot/acot-runner-storybook`
- `@acot/acot-runner-sitemap`

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a
