### PR TITLE
feat: allow multiple reporters

### DIFF
--- a/packages/config/src/resolver.ts
+++ b/packages/config/src/resolver.ts
@@ -188,7 +188,7 @@ export const resolveConfig = async (
 
     debug('valid config: %O', config);
 
-    const { runner, reporter, presets, overrides, viewport, ...rest } = config;
+    const { runner, reporters, presets, overrides, viewport, ...rest } = config;
     let resolved: ResolvedConfig = {
       ...rest,
       rules: normalizeRuleConfig(config.rules ?? {}),
@@ -196,15 +196,27 @@ export const resolveConfig = async (
 
     if (runner != null) {
       resolved.runner = loadRunner(
-        typeof runner === 'string' ? { uses: runner, with: {} } : runner,
+        typeof runner === 'string'
+          ? {
+              uses: runner,
+              with: {},
+            }
+          : runner,
         cwd,
       );
     }
 
-    if (reporter != null) {
-      resolved.reporter = loadReporter(
-        typeof reporter === 'string' ? { uses: reporter, with: {} } : reporter,
-        cwd,
+    if (reporters != null) {
+      resolved.reporters = reporters.map((reporter) =>
+        loadReporter(
+          typeof reporter === 'string'
+            ? {
+                uses: reporter,
+                with: {},
+              }
+            : reporter,
+          cwd,
+        ),
       );
     }
 

--- a/packages/config/src/validator/config.validator.ts
+++ b/packages/config/src/validator/config.validator.ts
@@ -109,29 +109,32 @@ export const ConfigSchema = {
           },
           type: 'array',
         },
-        reporter: {
-          anyOf: [
-            {
-              allOf: [
-                {
-                  $ref:
-                    '#/definitions/Pick<{with?:Record<string,any>;},"with">',
-                },
-                {
-                  properties: {
-                    uses: {
-                      $ref: '#/definitions/U',
-                    },
+        reporters: {
+          items: {
+            anyOf: [
+              {
+                allOf: [
+                  {
+                    $ref:
+                      '#/definitions/Pick<{with?:Record<string,any>;},"with">',
                   },
-                  required: ['uses'],
-                  type: 'object',
-                },
-              ],
-            },
-            {
-              type: 'string',
-            },
-          ],
+                  {
+                    properties: {
+                      uses: {
+                        $ref: '#/definitions/U',
+                      },
+                    },
+                    required: ['uses'],
+                    type: 'object',
+                  },
+                ],
+              },
+              {
+                type: 'string',
+              },
+            ],
+          },
+          type: 'array',
         },
         runner: {
           anyOf: [

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -69,7 +69,7 @@ export type Config = BaseConfig & {
   paths?: string[];
   connection?: ConnectionOptions;
   runner?: string | RunnerUses;
-  reporter?: string | ReporterUses;
+  reporters?: (string | ReporterUses)[];
   chromeChannel?: ChromeChannel;
   launchOptions?: LaunchOptions;
   viewport?: Viewport | string;
@@ -89,7 +89,7 @@ export type ResolvedConfig = Merge<
   Config,
   {
     runner?: ResolvedRunnerUses;
-    reporter?: ResolvedReporterUses;
+    reporters?: ResolvedReporterUses[];
     rules: NormalizedRuleConfig; // FIXME Delays normalization to the execution phase (because of poor usability as an API)
     presets?: Preset[];
     overrides?: ResolvedConfigEntry[];


### PR DESCRIPTION
## What does this change?

```diff
- $ acot run --reporter "@acot/pretty" --reporter-with "{...}"
+ $ acot run --reporters "@acot/pretty"
```

This PR has breaking change. The `--reporter-with` flag has been removed.

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a
