### PR TITLE
Fix a bug when Node not found on report

### DIFF
--- a/packages/acot-reporter-dot/src/index.ts
+++ b/packages/acot-reporter-dot/src/index.ts
@@ -112,7 +112,9 @@ export default createReporterFactory(({ config, stdout }) => (runner) => {
               const selector = res.selector;
               const code = pickup(html, selector, { color: false });
 
-              meta.push(code, `at "${selector}"`);
+              if (code != null) {
+                meta.push(code, `at "${selector}"`);
+              }
             }
 
             if (res.help) {

--- a/packages/acot-reporter-pretty/src/index.ts
+++ b/packages/acot-reporter-pretty/src/index.ts
@@ -298,7 +298,9 @@ export default createReporterFactory(
                   const selector = res.selector;
                   const code = pickup(html, selector, { color: false });
 
-                  meta.push(code, `at "${selector}"`);
+                  if (code != null) {
+                    meta.push(code, `at "${selector}"`);
+                  }
                 }
 
                 if (res.help) {

--- a/packages/document/src/doc-result-reporter.ts
+++ b/packages/document/src/doc-result-reporter.ts
@@ -64,8 +64,10 @@ export class DocResultReporter {
               color: false,
             });
 
-            meta.push(html);
-            meta.push(`at "${result.selector}"`);
+            if (html != null) {
+              meta.push(html);
+              meta.push(`at "${result.selector}"`);
+            }
           }
 
           meta.push(origin + generateDocPath(error.code));

--- a/packages/html-pickup/src/__tests__/index.test.ts
+++ b/packages/html-pickup/src/__tests__/index.test.ts
@@ -27,14 +27,20 @@ const html = `
 
 describe('pickup', () => {
   test('basic', () => {
-    const output = pickup(html, '#element');
+    const output = pickup(html, '#element') as string;
 
     expect(output).not.toBe(stripAnsi(output));
     expect(stripAnsi(output)).toMatchSnapshot();
   });
 
+  test('not found', () => {
+    const output = pickup('', '#element');
+
+    expect(output).toBe(null);
+  });
+
   test('disable color', () => {
-    const output = pickup(html, '#element', { color: false });
+    const output = pickup(html, '#element', { color: false }) as string;
 
     expect(output).toBe(stripAnsi(output));
   });

--- a/packages/html-pickup/src/index.ts
+++ b/packages/html-pickup/src/index.ts
@@ -112,7 +112,7 @@ export const pickup = (
   html: string,
   selector: string,
   options: Partial<PickupOptions> = {},
-): string => {
+): string | null => {
   const opts = {
     truncate: 120,
     color: true,
@@ -126,6 +126,10 @@ export const pickup = (
   const [node] = cssSelect(selector, parse(html), {
     adapter,
   }) as Node[];
+
+  if (node == null) {
+    return null;
+  }
 
   const output = stringify(node, chk);
 


### PR DESCRIPTION
## What does this change?

If the target node cannot be found in the reporting phase, the following error will occur.

```
 ERROR  TypeError: Cannot read property 'nodeName' of undefined
            at stringify (node_modules/@acot/html-pickup/lib/index.js:24:18)
            at Object.pickup (node_modules/@acot/html-pickup/lib/index.js:96:20)
            at node_modules/@acot/acot-reporter-pretty/lib/index.js:221:48
            at async Promise.all (index 46)
            at async node_modules/@acot/acot-reporter-pretty/lib/index.js:201:28
            at async Promise.all (index 0)
            at async node_modules/@acot/acot-reporter-pretty/lib/index.js:194:9
            at async Promise.all (index 0)
            at async Emittery.Typed.emit (node_modules/emittery/index.js:257:3)
            at async AcotRunner.handleAuditComplete (node_modules/@acot/acot-runner/lib/index.js:32:13)
```

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a