### PR TITLE
feat(acot-runner-sitemap): add behavior to merge `config.paths` with collected paths

### DIFF
--- a/packages/acot-runner-sitemap/src/__tests__/index.test.ts
+++ b/packages/acot-runner-sitemap/src/__tests__/index.test.ts
@@ -43,7 +43,6 @@ describe('Sitemap Runner', () => {
         );
 
         server.listen(PORT, () => {
-          console.log(server.listening);
           resolve();
         });
       }),
@@ -254,6 +253,27 @@ describe('Sitemap Runner', () => {
         expect.stringMatching(/\/guidelines\/(nest1|nest2)\/(bar|baz)/),
       ]),
     );
+  });
+
+  test('collect - merge paths', async () => {
+    const paths = ['/merge1.html', '/merge2.html'];
+
+    const sources = await new SitemapRunner({
+      ...config,
+      config: {
+        ...config.config,
+        paths,
+      },
+    })['collect']();
+
+    expect(Array.from(sources.keys())).toEqual([
+      ...paths,
+      '/',
+      '/page1?search=query',
+      '/page2?search=query#hash',
+      '/page3',
+      '/page4',
+    ]);
   });
 
   test('collect - source not found', async () => {

--- a/packages/acot-runner-sitemap/src/index.ts
+++ b/packages/acot-runner-sitemap/src/index.ts
@@ -123,8 +123,9 @@ const fetchSitemap = async (url: string, options: Options) => {
 
 export class SitemapRunner extends AcotRunner<Options> {
   protected async collect(): AcotRunnerCollectResult {
+    const sources = await super.collect();
+
     const router = new ConfigRouter(this.config);
-    const sources = new Map();
 
     let entries = await fetchSitemap(this.options.source, {
       timeout: DEFAULT_TIMEOUT,
@@ -135,6 +136,8 @@ export class SitemapRunner extends AcotRunner<Options> {
       this.options.limit != null
         ? entries.slice(0, this.options.limit)
         : entries;
+
+    debug('collected paths: %O', entries);
 
     entries.forEach((path) => {
       const entry = router.resolve(path);


### PR DESCRIPTION
## What does this change?

Added behavior to `config.paths` to merge the results of path collections sourced from sitemap :point_down:

```javascript
module.exports = {
  runner: {
    uses: '@acot/sitemap',
    with: {
      // `sitemap.xml` -> ['/path3.html', '/path4.html']
      source: 'https://acot.example/sitemap.xml',
    },
  },
  paths: [
    '/path1.html',
    '/path2.html',
  ],
};
```

**After:**

```
/path1.html
/path2.html
/path3.html
/path4.html
```

**Before:**

```
/path3.html
/path4.html
```

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a