### PR TITLE
Improve rule apply for hidden elements

### DIFF
--- a/packages/acot-preset-wcag/docs/rules/img-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/img-has-name.md
@@ -14,6 +14,14 @@ The `img` element or img role MUST has name.
 <svg role="img" aria-label="bear"></svg>
 ```
 
+If the element is not exposed to the accessibility API, name allows an empty.
+
+```html
+<div aria-hidden="true">
+  <img src="https://placebear.com/350/250" />
+</div>
+```
+
 ## :warning: Incorrect
 
 ```html

--- a/packages/acot-preset-wcag/docs/rules/interactive-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/interactive-has-name.md
@@ -25,6 +25,14 @@ Interactive elements MUST has name.
 <div id="div" tabindex="0">Element</div>
 ```
 
+If the element is not exposed to the accessibility API, name allows an empty.
+
+```html
+<div aria-hidden="true">
+  <button></button>
+</div>
+```
+
 ## :warning: Incorrect
 
 ```html

--- a/packages/acot-preset-wcag/docs/rules/link-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/link-has-name.md
@@ -18,6 +18,14 @@ Link MUST has name.
 >
 ```
 
+If the element is not exposed to the accessibility API, name allows an empty.
+
+```html
+<div aria-hidden="true">
+  <a href="https://www.w3.org/TR/WCAG21/#name-role-value"></a>
+</div>
+```
+
 ## :warning: Incorrect
 
 ```html

--- a/packages/acot-preset-wcag/package.json
+++ b/packages/acot-preset-wcag/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@acot/cli": "0.0.17-canary.2",
     "@acot/core": "0.0.17-canary.2",
+    "@acot/utils": "0.0.16",
     "language-tags": "^1.0.5",
     "p-limit": "3.1.0"
   },

--- a/packages/acot-preset-wcag/src/rules/img-has-name.ts
+++ b/packages/acot-preset-wcag/src/rules/img-has-name.ts
@@ -1,4 +1,5 @@
 import { createRule } from '@acot/core';
+import { isElementHidden } from '@acot/utils';
 
 type Options = {};
 
@@ -14,6 +15,11 @@ export default createRule<Options>({
     await Promise.all(
       nodes.map(async (node) => {
         try {
+          const hidden = await isElementHidden(node);
+          if (hidden) {
+            return;
+          }
+
           const name = await node.evaluate(async (el) => {
             const ax = await (window as any).getComputedAccessibleNode(el);
             return (ax?.name ?? '').trim();

--- a/packages/acot-preset-wcag/src/rules/interactive-has-name.ts
+++ b/packages/acot-preset-wcag/src/rules/interactive-has-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from '@acot/core';
-import { getEventListeners } from '@acot/utils';
 import type { ComputedAccessibleNode } from '@acot/types';
+import { getEventListeners, isElementHidden } from '@acot/utils';
 
 type Options = {};
 
@@ -33,6 +33,11 @@ export default createRule<Options>({
     await Promise.all(
       nodes.map(async (node) => {
         try {
+          const hidden = await isElementHidden(node);
+          if (hidden) {
+            return;
+          }
+
           const name = await node.evaluate(async (el) => {
             const ax = await ((window as any).getComputedAccessibleNode(
               el,

--- a/packages/acot-preset-wcag/src/rules/interactive-supports-focus.ts
+++ b/packages/acot-preset-wcag/src/rules/interactive-supports-focus.ts
@@ -1,5 +1,5 @@
 import { createRule } from '@acot/core';
-import { getEventListeners } from '@acot/utils';
+import { getEventListeners, isElementHidden } from '@acot/utils';
 
 // FIXME @masuP9
 
@@ -35,6 +35,11 @@ export default createRule<Options>({
     await Promise.all(
       nodes.map(async (node) => {
         try {
+          const hidden = await isElementHidden(node);
+          if (hidden) {
+            return;
+          }
+
           // if focusable
           // TODO refactor
           const focusable = await node.evaluate((el) => {

--- a/packages/acot-preset-wcag/src/rules/link-has-name.ts
+++ b/packages/acot-preset-wcag/src/rules/link-has-name.ts
@@ -1,4 +1,5 @@
 import { createRule } from '@acot/core';
+import { isElementHidden } from '@acot/utils';
 
 type Options = {};
 
@@ -14,6 +15,11 @@ export default createRule<Options>({
     await Promise.all(
       nodes.map(async (node) => {
         try {
+          const hidden = await isElementHidden(node);
+          if (hidden) {
+            return;
+          }
+
           const name = await node.evaluate(async (el) => {
             const ax = await (window as any).getComputedAccessibleNode(el);
             return (ax?.name ?? '').trim();

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './get-event-listeners';
+export * from './is-element-hidden';
 export * from './is-filepath';
 export * from './naming';
 export * from './parse-viewport';

--- a/packages/utils/src/is-element-hidden.ts
+++ b/packages/utils/src/is-element-hidden.ts
@@ -1,0 +1,44 @@
+import type { ElementHandle } from 'puppeteer-core';
+
+/**
+ * @see https://chromedevtools.github.io/devtools-protocol/tot/Accessibility/#method-queryAXTree
+ */
+export const isElementHidden = async (
+  element: ElementHandle,
+): Promise<boolean> => {
+  const [
+    {
+      node: { backendNodeId },
+    },
+    { nodes },
+  ] = await Promise.all([
+    element._client.send('DOM.describeNode', {
+      objectId: element._remoteObject.objectId,
+    }),
+    element._client.send('Accessibility.queryAXTree', {
+      objectId: element._remoteObject.objectId,
+    }),
+  ]);
+
+  const node = nodes.find((o) => o.backendDOMNodeId === backendNodeId);
+  if (node == null) {
+    return false;
+  }
+
+  // Even if it is ignored for accessibility, it is judged to be hidden.
+  if (node.ignored) {
+    return true;
+  }
+
+  if (node.properties == null) {
+    return false;
+  }
+
+  for (const prop of node.properties) {
+    if (prop.name === 'hidden') {
+      return prop.value.value === true;
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## What does this change?

Previously, the following elements did not get the accessible name :point_down:

```html
<div aria-hidden="true">
  <a href="#">Link Element</a>
</div>
```

This element should be ignored when using assistive techniques and should not be reported as an error.
Therefore, we have added logic to exclude elements that are determined to be hidden from some rules.

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a