### PR TITLE
Add `ignore` option to `acot-preset-wcag` rules

### DIFF
--- a/packages/acot-preset-wcag/docs/rules/dialog-focus.md
+++ b/packages/acot-preset-wcag/docs/rules/dialog-focus.md
@@ -6,6 +6,14 @@ Move focus to inside dialog or set dialog after trigger.
 
 [Understanding Success Criterion 2\.4\.3: Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 ```html
@@ -38,6 +46,18 @@ Move focus to inside dialog or set dialog after trigger.
     dialog.hidden = false;
   });
 </script>
+```
+
+**Example:** `ignore: '[data-testid="dialog"]'`
+
+The button does not respond, but does not report an error because it is excluded.
+
+```html ignore:"[data-testid='dialog']"
+<button type="button" aria-haspopup="dialog" data-testid="dialog">open</button>
+
+<dialog>
+  <button type="type">OK</button>
+</dialog>
 ```
 
 ## :warning: Incorrect

--- a/packages/acot-preset-wcag/docs/rules/img-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/img-has-name.md
@@ -6,6 +6,14 @@ The `img` element or img role MUST has name.
 
 [WCAG 2.1 - 1.1.1: Non-text Content](https://www.w3.org/TR/WCAG21/#non-text-content)
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 ```html
@@ -20,6 +28,14 @@ If the element is not exposed to the accessibility API, name allows an empty.
 <div aria-hidden="true">
   <img src="https://placebear.com/350/250" />
 </div>
+```
+
+**Example:** `ignore: '[data-testid="img"]'`
+
+Some `img` element can be ignored by specifying the `ignore` option.
+
+```html ignore:"[data-testid='img']"
+<img src="https://placebear.com/350/250" data-testid="img" />
 ```
 
 ## :warning: Incorrect

--- a/packages/acot-preset-wcag/docs/rules/interactive-has-enough-size.md
+++ b/packages/acot-preset-wcag/docs/rules/interactive-has-enough-size.md
@@ -4,6 +4,14 @@ The size of the target for pointer inputs is at least 44 by 44 CSS pixels.
 
 [Understanding Success Criterion 2.5.5: Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 Allow UA default styles.
@@ -24,6 +32,19 @@ Adequately sized targets.
 
 ```html
 <button style="display: inline-block; width: 44px; height: 44px;">
+  Small button
+</button>
+```
+
+**Example:** `ignore: '[data-testid="small"]'`
+
+You can use the `ignore` option to ignore certain buttons.
+
+```html ignore:"[data-testid='small']"
+<button
+  style="display: inline-block; width: 43px; height: 43px;"
+  data-testid="small"
+>
   Small button
 </button>
 ```

--- a/packages/acot-preset-wcag/docs/rules/interactive-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/interactive-has-name.md
@@ -6,6 +6,14 @@ Interactive elements MUST has name.
 
 [WCAG 2.1 - 4.1.2: Name, Role, Value](https://www.w3.org/TR/WCAG21/#name-role-value)
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 ```html
@@ -31,6 +39,14 @@ If the element is not exposed to the accessibility API, name allows an empty.
 <div aria-hidden="true">
   <button></button>
 </div>
+```
+
+**Example:** `ignore: '[data-testid="aware-invalid-button"]'`
+
+You can use the `ignore` option to ignore certain buttons.
+
+```html ignore:"[data-testid='aware-invalid-button']"
+<button data-testid="aware-invalid-button"></button>
 ```
 
 ## :warning: Incorrect

--- a/packages/acot-preset-wcag/docs/rules/interactive-supports-focus.md
+++ b/packages/acot-preset-wcag/docs/rules/interactive-supports-focus.md
@@ -2,6 +2,14 @@
 
 _T.B.A_
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 ```html
@@ -20,6 +28,20 @@ _T.B.A_
   };
   div.addEventListener('click', handler, false);
   div.addEventListener('keydown', handler, false);
+</script>
+```
+
+**Example:** `ignore: '[data-testid="ignore"]'`
+
+```html ignore:"[data-testid='ignore']"
+<div id="div" tabindex="0" data-testid="ignore">Element</div>
+
+<script>
+  const div = document.getElementById('div');
+  const handler = () => {
+    /* ... */
+  };
+  div.addEventListener('click', handler, false);
 </script>
 ```
 

--- a/packages/acot-preset-wcag/docs/rules/link-has-name.md
+++ b/packages/acot-preset-wcag/docs/rules/link-has-name.md
@@ -10,6 +10,14 @@ Link MUST has name.
 
 [WCAG 2.1 - 4.1.2 Name, Role, Value](https://www.w3.org/TR/WCAG21/#name-role-value)
 
+## Options
+
+### `ignore: string | string[]`
+
+**Default:** None
+
+Ignores the element specified in the selector string from the validation target.
+
 ## :white_check_mark: Correct
 
 ```html
@@ -24,6 +32,17 @@ If the element is not exposed to the accessibility API, name allows an empty.
 <div aria-hidden="true">
   <a href="https://www.w3.org/TR/WCAG21/#name-role-value"></a>
 </div>
+```
+
+**Example:** `ignore: '[data-testid="aware-invalid-link"]'`
+
+The button does not respond, but does not report an error because it is excluded.
+
+```html ignore:"[data-testid='aware-invalid-link']"
+<a
+  href="https://www.w3.org/TR/WCAG21/#name-role-value"
+  data-testid="aware-invalid-link"
+></a>
 ```
 
 ## :warning: Incorrect

--- a/packages/acot-preset-wcag/package.json
+++ b/packages/acot-preset-wcag/package.json
@@ -37,6 +37,7 @@
     "@acot/cli": "0.0.17",
     "@acot/core": "0.0.17",
     "@acot/utils": "0.0.17",
+    "@sinclair/typebox": "^0.23.2",
     "language-tags": "^1.0.5",
     "p-limit": "3.1.0"
   },

--- a/packages/acot-preset-wcag/src/rules/img-has-name.ts
+++ b/packages/acot-preset-wcag/src/rules/img-has-name.ts
@@ -1,22 +1,45 @@
 import { createRule } from '@acot/core';
-import { isElementHidden } from '@acot/utils';
+import { isElementHidden, isElementMatches } from '@acot/utils';
+import type { Static } from '@sinclair/typebox';
+import { Type } from '@sinclair/typebox';
 
-type Options = {};
+const schema = Type.Strict(
+  Type.Object(
+    {
+      ignore: Type.Optional(
+        Type.Union([Type.String(), Type.Array(Type.String())]),
+      ),
+    },
+    {
+      additionalProperties: false,
+    },
+  ),
+);
+
+type Options = Static<typeof schema>;
 
 export default createRule<Options>({
+  schema,
+
   meta: {
     help: 'https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html',
     recommended: true,
   },
 
   test: async (context) => {
+    const { ignore } = context.options;
+
     const nodes = await context.page.$$('aria/[role="img"]');
 
     await Promise.all(
       nodes.map(async (node) => {
         try {
-          const hidden = await isElementHidden(node);
-          if (hidden) {
+          const [hidden, ignored] = await Promise.all([
+            isElementHidden(node),
+            isElementMatches(node, ignore ?? []),
+          ]);
+
+          if (hidden || ignored) {
             return;
           }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './get-event-listeners';
 export * from './is-element-hidden';
+export * from './is-element-matches';
 export * from './is-filepath';
 export * from './naming';
 export * from './parse-viewport';

--- a/packages/utils/src/is-element-matches.ts
+++ b/packages/utils/src/is-element-matches.ts
@@ -1,0 +1,16 @@
+import type { ElementHandle } from 'puppeteer-core';
+
+export const isElementMatches = async (
+  element: ElementHandle,
+  selectors: string | string[],
+): Promise<boolean> => {
+  const targets = Array.isArray(selectors) ? selectors : [selectors];
+  if (targets.length === 0) {
+    return false;
+  }
+
+  return await element.evaluate(
+    (el, list: string[]) => list.some((selector) => el.matches(selector)),
+    targets,
+  );
+};


### PR DESCRIPTION
## What does this change?

Added `ignore` option to some rules.

```json
{
  "rules": {
    "@acot/wcag/link-has-name": ["error", { "ignore": "[data-testid='...']" }]
  }
}
```

Option to ignore elements matching the selector string from the checks.

This option is useful for 3rd-party SDKs or cases that are difficult to support due to technical or design backgrounds.

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- n/a