### PR TITLE
feat(acot-runner-sitemap): add retry behavior to sitemap fetcher

### DIFF
--- a/packages/acot-runner-sitemap/README.md
+++ b/packages/acot-runner-sitemap/README.md
@@ -160,7 +160,7 @@ The key-value of the header used when fetching the `sitemap.xml` specified in [s
 ### `timeout`
 
 **Type:** `number`  
-**Default:** `60000`  
+**Default:** `30000`  
 **Required:** `false`
 
 Maximum time in milliseconds to wait for collecting sitemaps.
@@ -171,6 +171,24 @@ Maximum time in milliseconds to wait for collecting sitemaps.
   "with": {
     "source": "https://acot.example/sitemap.xml",
     "timeout": 120000
+  }
+}
+```
+
+### `retry`
+
+**Type:** `number`  
+**Default:** `3`  
+**Required:** `false`
+
+The maximum retry count.
+
+```json
+{
+  "runner": "@acot/sitemap",
+  "with": {
+    "source": "https://acot.example/sitemap.xml",
+    "retry": 2
   }
 }
 ```

--- a/packages/acot-runner-sitemap/package.json
+++ b/packages/acot-runner-sitemap/package.json
@@ -44,9 +44,9 @@
     "@sinclair/typebox": "^0.23.2",
     "camaro": "^6.0.4",
     "debug": "^4.3.1",
+    "got": "11.8.3",
     "lodash": "^4.17.19",
     "micromatch": "^4.0.2",
-    "node-fetch": "^2.6.1",
     "puppeteer-core": "^13.5.1",
     "serve-handler": "^6.1.3"
   },
@@ -55,7 +55,6 @@
     "@acot/types": "0.0.18",
     "@types/lodash": "4.14.182",
     "@types/micromatch": "4.0.2",
-    "@types/node-fetch": "2.6.1",
     "@types/serve-handler": "6.1.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,7 +4972,7 @@
   resolved "https://registry.yarnpkg.com/@types/node-emoji/-/node-emoji-1.8.1.tgz#689cb74fdf6e84309bcafce93a135dfecd01de3f"
   integrity sha512-0fRfA90FWm6KJfw6P9QGyo0HDTCmthZ7cWaBQndITlaWLTZ6njRyKwrwpzpg+n6kBXBIGKeUHEQuBx7bphGJkA==
 
-"@types/node-fetch@2.6.1", "@types/node-fetch@^2.5.7":
+"@types/node-fetch@^2.5.7":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
   integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==


### PR DESCRIPTION
## What does this change?

Because sitemap retrieval is over the network, the behavior is sometimes unstable. so retries are added to ensure stable testing.

## Screenshots

n/a

## What can I check for bug fixes?

n/a

## References

- [got/7-retry.md at main · sindresorhus/got](https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md)